### PR TITLE
Add 'config_dir' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ e.g.
     <td>User to install .s3cfg config file</td>
     <td><tt>ubuntu</tt></td>
   </tr>
+  <tr>
+    <td><tt>['s3cmd']['config_dir']</tt></td>
+    <td>String</td>
+    <td>Directory where the .s3cfg config file will be installed.  This must be explicitly set if the user account is created by chef.</td>
+    <td><tt>['s3cmd']['user']'s home directory</tt></td>
+  </tr>
 </table>
 
 Usage

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,11 @@ bash "install-s3cmd" do
   EOH
 end
 
-home_folder = `echo ~#{node['s3cmd']['user']}`.strip
+if node['s3cmd']['config_dir']
+  home_folder = node['s3cmd']['config_dir']
+else
+  home_folder = node['etc']['passwd'][node['s3cmd']['user']]['dir']
+end
 
 template "#{home_folder}/.s3cfg" do
   source "s3cfg.erb"


### PR DESCRIPTION
Allows the directory where the config file is written to be explicitly set.  This is needed if the user's home directory has not been created yet when this cookbook is loaded.
