### PR TITLE
S3cmd now depends on python requests

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,7 @@ package "python"
 package "python-setuptools"
 package "python-distutils-extra"
 package "python-dateutil"
+package "python-requests"
 
 package "s3cmd"
 


### PR DESCRIPTION
Add the python requests package on the machine before installing s3cmd
