### PR TITLE
Add chef vault support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  data_bags_path: test/fixtures/data_bags
 
 platforms:
   - name: ubuntu-14.04
@@ -17,3 +18,7 @@ suites:
       s3cmd:
         user: vagrant
         config_dir: /home/vagrant
+        data_bag: {
+          name: 'aws_creds',
+          item: 's3_user'
+        }

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+#  - name: centos-7.1
+
+suites:
+  - name: default
+    run_list:
+      - recipe[s3cmd::default]
+    attributes:
+      s3cmd:
+        user: vagrant
+        config_dir: /home/vagrant

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,5 @@
+source "https://supermarket.chef.io"
+
+metadata
+
+cookbook 'chef-vault', '~> 1.3.2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+
+# Uncomment these lines if you want to live on the Edge:
+#
+# group :development do
+#   gem "berkshelf", github: "berkshelf/berkshelf"
+#   gem "vagrant", github: "mitchellh/vagrant", tag: "v1.6.3"
+# end
+#
+# group :plugins do
+#   gem "vagrant-berkshelf", github: "berkshelf/vagrant-berkshelf"
+#   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
+# end
+
+gem 'test-kitchen'
+gem 'kitchen-vagrant'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,6 @@
 # https://github.com/fred/chef-s3cmd
 #
 
-
 # Url to download the tarball from latest master branch from github.
 default['s3cmd']['url'] = 'https://github.com/s3tools/s3cmd/archive/master.tar.gz'
 default['s3cmd']['gpg_passphrase'] = 'abcdefgabcdefgabcdefgabcdefg'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,7 @@ default['s3cmd']['bucket_location'] = 'US'
 default['s3cmd']['encrypt'] = false
 default['s3cmd']['https'] = false
 default['s3cmd']['user'] = 'ubuntu' # User *must* exist, otherwise don't expect this to work ; )
+# default['s3cmd']['data_bag'] = {
+#   name: 'aws_creds',
+#   item: 's3_user'
+# }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,4 +14,4 @@ default['s3cmd']['access_key'] = 'AAAAAAAAAAAAAAAAAAAA'
 default['s3cmd']['bucket_location'] = 'US'
 default['s3cmd']['encrypt'] = false
 default['s3cmd']['https'] = false
-default['s3cmd']['user'] = 'ubuntu'
+default['s3cmd']['user'] = 'ubuntu' # User *must* exist, otherwise don't expect this to work ; )

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,1 @@
+.kitchen

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,7 @@
   "platforms": {
   },
   "dependencies": {
+    "chef-vault": "~> 1.3.2"
   },
   "recommendations": {
   },

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
-name             's3cmd'
-maintainer       'Frederico Araujo'
+name 's3cmd'
+maintainer 'Frederico Araujo'
 maintainer_email 'fred.the.master@gmail.com'
-license          'All rights reserved'
-description      'Installs latest s3cmd from master branch at github (alpha)'
+license 'All rights reserved'
+description 'Installs latest s3cmd from master branch at github (alpha)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version '0.2.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license 'All rights reserved'
 description 'Installs latest s3cmd from master branch at github (alpha)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.1'
+
+depends 'chef-vault', '~> 1.3.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,13 +5,13 @@
 # https://github.com/fred/chef-s3cmd
 #
 
-package "python"
-package "python-setuptools"
-package "python-distutils-extra"
-package "python-dateutil"
-package "python-requests"
+package 'python'
+package 'python-setuptools'
+package 'python-distutils-extra'
+package 'python-dateutil'
+package 'python-requests'
 
-package "s3cmd"
+package 's3cmd'
 
 if node['s3cmd']['config_dir']
   home_folder = node['s3cmd']['config_dir']
@@ -20,14 +20,14 @@ else
 end
 
 template "#{home_folder}/.s3cfg" do
-  source "s3cfg.erb"
+  source 's3cfg.erb'
   variables(
-    :access_key =>  node['s3cmd']['access_key'],
-    :secret_key =>  node['s3cmd']['secret_key'],
-    :gpg_passphrase =>  node['s3cmd']['gpg_passphrase'],
-    :bucket_location =>  node['s3cmd']['bucket_location'],
-    :https =>  node['s3cmd']['https'],
-    :encrypt =>  node['s3cmd']['encrypt']
+    access_key: node['s3cmd']['access_key'],
+    secret_key: node['s3cmd']['secret_key'],
+    gpg_passphrase: node['s3cmd']['gpg_passphrase'],
+    bucket_location: node['s3cmd']['bucket_location'],
+    https: node['s3cmd']['https'],
+    encrypt: node['s3cmd']['encrypt']
   )
   owner node['s3cmd']['user']
   group node['s3cmd']['user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,14 +23,20 @@ include_recipe 'chef-vault'
 
 begin
   # First try to load s3 config through Chef Vault, as the more secure way.
-  s3cfg_variables = {
-    access_key: chef_vault_item_for_environment('aws_creds', 's3_user')['access_key'],
-    secret_key: chef_vault_item_for_environment('aws_creds', 's3_user')['secret_key'],
-    gpg_passphrase: chef_vault_item_for_environment('aws_creds', 's3_user')['gpg_passphrase'],
-    bucket_location: chef_vault_item_for_environment('aws_creds', 's3_user')['bucket_location'],
-    https: chef_vault_item_for_environment('aws_creds', 's3_user')['https'],
-    encrypt: chef_vault_item_for_environment('aws_creds', 's3_user')['encrypt']
-  }
+  if node['s3cmd']['data_bag']
+    data_bag_name = node['s3cmd']['data_bag']['name']
+    data_bag_item_name = node['s3cmd']['data_bag']['item']
+    s3cfg_variables = {
+      access_key: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['access_key'],
+      secret_key: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['secret_key'],
+      gpg_passphrase: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['gpg_passphrase'],
+      bucket_location: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['bucket_location'],
+      https: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['https'],
+      encrypt: chef_vault_item_for_environment(data_bag_name, data_bag_item_name)['encrypt']
+    }
+  else
+    raise ChefVault::Exceptions::KeysNotFound.new('data bag not declared, reverting to attributes') # caught immediately below
+  end
 rescue ChefVault::Exceptions::KeysNotFound, Net::HTTPServerException => e
   if e || e.response_code == '404'
     # if we couldn't find the data bag, revert to plain node attributes

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,16 +19,36 @@ else
   home_folder = node['etc']['passwd'][node['s3cmd']['user']]['dir']
 end
 
+include_recipe 'chef-vault'
+
+begin
+  # First try to load s3 config through Chef Vault, as the more secure way.
+  s3cfg_variables = {
+    access_key: chef_vault_item_for_environment('aws_creds', 's3_user')['access_key'],
+    secret_key: chef_vault_item_for_environment('aws_creds', 's3_user')['secret_key'],
+    gpg_passphrase: chef_vault_item_for_environment('aws_creds', 's3_user')['gpg_passphrase'],
+    bucket_location: chef_vault_item_for_environment('aws_creds', 's3_user')['bucket_location'],
+    https: chef_vault_item_for_environment('aws_creds', 's3_user')['https'],
+    encrypt: chef_vault_item_for_environment('aws_creds', 's3_user')['encrypt']
+  }
+rescue ChefVault::Exceptions::KeysNotFound, Net::HTTPServerException => e
+  if e || e.response_code == '404'
+    # if we couldn't find the data bag, revert to plain node attributes
+    s3cfg_variables = {
+      access_key: node['s3cmd']['access_key'],
+      secret_key: node['s3cmd']['secret_key'],
+      gpg_passphrase: node['s3cmd']['gpg_passphrase'],
+      bucket_location: node['s3cmd']['bucket_location'],
+      https: node['s3cmd']['https'],
+      encrypt: node['s3cmd']['encrypt']
+    }
+  end
+end
+
+
 template "#{home_folder}/.s3cfg" do
   source 's3cfg.erb'
-  variables(
-    access_key: node['s3cmd']['access_key'],
-    secret_key: node['s3cmd']['secret_key'],
-    gpg_passphrase: node['s3cmd']['gpg_passphrase'],
-    bucket_location: node['s3cmd']['bucket_location'],
-    https: node['s3cmd']['https'],
-    encrypt: node['s3cmd']['encrypt']
-  )
+  variables s3cfg_variables
   owner node['s3cmd']['user']
   group node['s3cmd']['user']
   mode 0600

--- a/test/fixtures/data_bags/aws_creds/s3_user.json
+++ b/test/fixtures/data_bags/aws_creds/s3_user.json
@@ -1,0 +1,12 @@
+{
+  "id": "s3_user",
+  "_default": {
+    "username": "your_user",
+    "access_key": "insert_your_access_key_here",
+    "secret_key": "insert_your_secret_key_here",
+    "https": true,
+    "encrypt": false,
+    "gpg_passphrase": "",
+    "bucket_location": "EU"
+  }
+}


### PR DESCRIPTION
This PR adds Chef Vault support to this cookbook, so that aws access/secret keys. etc. can be securely retrieved by chef server, where they can remain stored encrypted (as opposed to maintaining plain text versions in the Chef Server / source control). 

Please let me know if you need something fixed before having this merged in. 
